### PR TITLE
Bump hexo from 8.1.1 to 8.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "hexo-site",
       "version": "0.0.0",
       "dependencies": {
-        "hexo": "^8.1.1",
+        "hexo": "^8.1.2",
         "hexo-deployer-git": "^4.0.0",
         "hexo-filter-github-emojis": "^3.0.5",
         "hexo-filter-mermaid-diagrams": "^1.0.5",
@@ -1290,9 +1290,9 @@
       }
     },
     "node_modules/hexo": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmmirror.com/hexo/-/hexo-8.1.1.tgz",
-      "integrity": "sha512-UnzT4ImjKzMMuVRsvudxrl7MkdZwKe4S9xJN5pQPK9c+K0G+fLFb9kB6CqZZwj2E5ne+QK0ls4XMKqTUbNR3RQ==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/hexo/-/hexo-8.1.2.tgz",
+      "integrity": "sha512-gmpNwL1KnbK12q551ZhGxqvSw8M88ZSjFKOhx6ybUYz1phjPdwGewMgBgwGmjcVcIYFq6tWQAv1MRil/sBrPHQ==",
       "license": "MIT",
       "dependencies": {
         "abbrev": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "server": "hexo server"
   },
   "hexo": {
-    "version": "8.1.1"
+    "version": "8.1.2"
   },
   "dependencies": {
-    "hexo": "^8.1.1",
+    "hexo": "^8.1.2",
     "hexo-deployer-git": "^4.0.0",
     "hexo-filter-github-emojis": "^3.0.5",
     "hexo-filter-mermaid-diagrams": "^1.0.5",


### PR DESCRIPTION
## 升级 hexo 8.1.1 → 8.1.2

patch release，仅 bugfix + 性能 + refactor，**无 breaking change**。

### 变更内容
- fix(external_link)：`noopenner` 拼写修正为 `noopener`
- fix：转义 Swig/HTML 注释时单行代码块被错误忽略
- perf：更快的 externalLink 正则
- refactor：loadPlugin 移除 node 内部 API 用法

### 环境
- Node 要求 `>=20.19.0`（hexo 8.0.0 已砍 Node 16/18），当前 Node v24.18.0 ✓

### 验证
`npx hexo clean && npx hexo generate` → 139 files generated in 791ms，零报错。

### 改动文件
- `package.json`：hexo.version `8.1.1`→`8.1.2`，依赖范围 `^8.1.1`→`^8.1.2`
- `package-lock.json`：锁定 hexo@8.1.2

> next 主题（8.27.0）及其余 13 个插件均已为最新，未改动。