### PR TITLE
Enable edit-this-page link on each post

### DIFF
--- a/_config.next.yml
+++ b/_config.next.yml
@@ -297,9 +297,8 @@ related_posts:
 # Post edit
 # Dependencies: https://github.com/hexojs/hexo-deployer-git
 post_edit:
-  enable: false
-  url: https://github.com/user-name/repo-name/tree/branch-name/subdirectory-name # Link for view source
-  #url: https://github.com/user-name/repo-name/edit/branch-name/subdirectory-name # Link for fork & edit
+  enable: true
+  url: https://github.com/pkking/pkking.github.io/edit/hexo/source/ # Link for fork & edit
 
 # Show previous post and next post in post footer if exists
 # Available values: left | right | false


### PR DESCRIPTION
## 为每篇博客添加 "edit this page" 链接

利用 NexT 主题**内置**的 `post_edit` 功能（无需任何自定义代码或新依赖）。

### 改动
`_config.next.yml` 的 `post_edit` 段：
- `enable: false` → `true`
- `url` 指向本仓库 `edit` 端点

```yaml
post_edit:
  enable: true
  url: https://github.com/pkking/pkking.github.io/edit/hexo/source/
```

### 效果
每篇 post 标题旁出现 ✏️ 图标（`fa-pen-nib`），点击跳转到 GitHub 对应源文件的编辑页：

```
https://github.com/pking/pkking.github.io/edit/hexo/source/_posts/<post>.md
```

NexT helper 将 `post_edit.url + post.source` 拼接而成，`post.source` 形如 `_posts/analysis-1.md`。

### 验证
`npx hexo clean && npx hexo generate` → 139 files generated in 822ms，零报错。生成的 HTML 中 11 个 post 页面均含 `class="post-edit-link"` 链接，`target="_blank"`、本地化 title「编辑」。

### 选 `edit/` 而非 `tree/` 的理由
`edit/branch/path` 直接打开 GitHub 网页编辑器（本仓库自有，可直接 commit）；`tree/` 仅只读浏览。需求是 "edit this page"，故取 `edit`。若想改成只读查看源码，把 url 里的 `edit` 换成 `tree` 即可。