### PR TITLE
Enable edit-this-page link on each post

### DIFF
--- a/_config.next.yml
+++ b/_config.next.yml
@@ -297,9 +297,8 @@ related_posts:
 # Post edit
 # Dependencies: https://github.com/hexojs/hexo-deployer-git
 post_edit:
-  enable: false
-  url: https://github.com/user-name/repo-name/tree/branch-name/subdirectory-name # Link for view source
-  #url: https://github.com/user-name/repo-name/edit/branch-name/subdirectory-name # Link for fork & edit
+  enable: true
+  url: https://github.com/pkking/pkking.github.io/edit/hexo/source/ # Link for fork & edit
 
 # Show previous post and next post in post footer if exists
 # Available values: left | right | false


### PR DESCRIPTION
## 为每篇博客添加 "edit this page" 链接

利用 NexT 主题**内置**的 `post_edit` 功能，无需自定义代码或新依赖。

### 改动（`_config.next.yml`，仅 2 行）

```yaml
post_edit:
  enable: true                                              # false → true
  url: https://github.com/pkking/pkking.github.io/edit/hexo/source/
```

### 效果
每篇 post 标题旁出现 ✏️ 图标（`fa-pen-nib`），点击直达 GitHub 对应源文件编辑页：

```
https://github.com/pkking/pkking.github.io/edit/hexo/source/_posts/<post>.md
```

NexT helper 将 `post_edit.url + post.source` 拼接（`post.source` 形如 `_posts/analysis-1.md`）。新标签打开，title 本地化为「编辑」。

### 验证
`npx hexo clean && npx hexo generate` → 139 files generated in 822ms，零报错；11 个 post 页面 HTML 均含 `class="post-edit-link"`。

### 选 `edit/` 而非 `tree/`
`edit/branch/path` 直接打开 GitHub 网页编辑器（本仓库自有，可直接 commit）；`tree/` 仅只读浏览。需求是 "edit this page"，故取 `edit`。若想改只读查看，url 里 `edit` → `tree` 即可。

### 基线
已 rebase 到最新 `hexo` 分支（含 hexo 8.1.2 升级 #36 及 dependabot #28/#29），无冲突。