### PR TITLE
Fix: strip leaked swig comment from head.swig

### DIFF
--- a/source/_data/head.swig
+++ b/source/_data/head.swig
@@ -1,6 +1,2 @@
-{# Web fonts via fonts.loli.net (Google Fonts CN mirror). No self-hosting.
-   ponytail: jsdelivr/googleapis blocked in China; loli.net mirrors both the css2 API
-   (unicode-range sliced woff2 for CJK) and gstatic font files. Browsers fetch only the
-   slices they need. Source Code Pro = latin/code; Noto Sans SC = CJK. #}
 <link rel="stylesheet" href="https://fonts.loli.net/css2?family=Source+Code+Pro:wght@400;700&display=swap">
 <link rel="stylesheet" href="https://fonts.loli.net/css2?family=Noto+Sans+SC:wght@400;700&display=swap">


### PR DESCRIPTION
## 修复页面顶部泄漏的 \`{# ... #}\` 注释

### 现象
PR #39 合入后，每个页面顶部出现一行：
\`\`\`
{# Web fonts via fonts.loli.net (Google Fonts CN mirror). No self-hosting. ... #}
\`\`\`

### 原因
\`source/_data/head.swig\` 里的 \`{# ... #}\` 是 Swig/Nunjucks **模板注释**，本该渲染时剔除。但项目**未装 swig 渲染器**（NexT v8 用内置 nunjunks 处理主模板，对 \`custom_file_path\` 注入的 \`.swig\` 文件，Hexo 无对应渲染器，按**纯文本**原样输出）——\`<link>\` 是纯 HTML 正常出来，\`{# #}\` 没被解析就泄漏到页面了。

> 背景：PR #39 是 squash merge，合入时这条注释修复尚未 push，故 leak 进了默认分支。

### 修复
删掉 \`head.swig\` 里那行注释，只留两条 \`<link>\`（标签本身不需要注释）。

\`\`\`diff
- {# Web fonts via fonts.loli.net ... #}
  <link rel="stylesheet" href="https://fonts.loli.net/css2?family=Source+Code+Pro:wght@400;700&display=swap">
  <link rel="stylesheet" href="https://fonts.loli.net/css2?family=Noto+Sans+SC:wght@400;700&display=swap">
\`\`\`

### 验证
- \`grep "Web fonts via fonts.loli.net"\` → 0
- \`grep '{#'\` → 0
- 两条 loli CDN 字体链接仍在
- 115 files / 789ms，零报错

→ 1 file changed, 4 deletions。无新依赖、无配置改动。